### PR TITLE
Update .eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
-    "prettier/@typescript-eslint",
+    "prettier",
   ],
   rules: {
     ...jsConfig.rules,


### PR DESCRIPTION
As of [prettier 8](https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21), this got simplified. It looks like Ajv still has v2 pinned, however, without updating the config here and releasing, it's impossible to update the other dependencies.