### PR TITLE
Added inlineSources to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "sourceMap": true,
+    "inlineSources": true,
     "strict": true,
     "strictNullChecks": true,
     "target": "ES2018",


### PR DESCRIPTION
Hello, I'm getting this error in Chrome dev tools when trying to debug errors in ajv files:
```
Could not load content for https://xxx.com/node_modules/ajv/lib/compile/index.ts (HTTP error: status code 404, net::ERR_HTTP_RESPONSE_CODE_FAILURE)
```

Although ajv is generating source maps, ts files are not added as part of them. Adding the option `"inlineSources": true` should solve the problem.