### PR TITLE
chore: set prettier trailing commas to es5

### DIFF
--- a/prettierrc.json
+++ b/prettierrc.json
@@ -1,5 +1,6 @@
 {
   "bracketSpacing": false,
   "semi": false,
-  "printWidth": 100
+  "printWidth": 100,
+  "trailingComma": "es5"
 }


### PR DESCRIPTION
The default changed in the latest version of prettier so we need this in order to update with minimal changes.